### PR TITLE
A bit of housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .turbo
 /.pnpm-store/
+**/*.obj
+**/*.step

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /dist
 /target
 /packages/cadmium/target
-/.svelte-kit
+**/.svelte-kit
 /package
 *.env*
 vite.config.js.timestamp-*

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ To build and run the Rust tests:
 cargo test
 ```
 
+### rust examples
+
+Simple exaples using the rust code can be found in `packages/cadmium/examples`
+
+Run simple rust example with:
+```
+cargo run --example project_simple_extrusion
+```
+
+Will produce example.obj file and example.step output files, the .step file can be examined in a CAD viewer.
+
 ## git blame
 
 To ignore commits used purely for formatting changes, to preserve correct authorship, set your local git config:

--- a/packages/cadmium/examples/project_simple_extrusion.rs
+++ b/packages/cadmium/examples/project_simple_extrusion.rs
@@ -1,0 +1,39 @@
+use cadmium::{
+    extrusion::{Direction, Extrusion, ExtrusionMode},
+    project::Project,
+};
+
+fn main() {
+    let mut p = Project::new("Example Project");
+    let wb = p.workbenches.get_mut(0).unwrap();
+    wb.add_sketch_to_plane("Sketch 1", "Plane-0");
+    let s = wb.get_sketch_mut("Sketch 1").unwrap();
+    let ll = s.add_point(0.0, 0.0);
+    let lr = s.add_point(40.0, 0.0);
+    let ul = s.add_point(0.0, 40.0);
+    let ur = s.add_point(40.0, 40.0);
+    s.add_segment(ll, lr);
+    s.add_segment(lr, ur);
+    s.add_segment(ur, ul);
+    s.add_segment(ul, ll);
+
+    let extrusion = Extrusion::new(
+        "Sketch-0".to_owned(),
+        vec![0],
+        25.0,
+        0.0,
+        Direction::Normal,
+        ExtrusionMode::New,
+    );
+    wb.add_extrusion("Ext1", extrusion);
+
+    let realization = p.get_realization(0, 1000);
+    let solids = realization.solids;
+    let solid = &solids["Ext1:0"];
+
+    println!("{:?}", solid);
+
+    println!("Dump example files");
+    solid.save_as_step("example.step");
+    solid.save_as_obj("example.obj", 0.001);
+}

--- a/packages/cadmium/src/workbench.rs
+++ b/packages/cadmium/src/workbench.rs
@@ -493,3 +493,57 @@ impl Workbench {
         realized
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use crate::extrusion::Direction;
+
+    use super::*;
+
+    #[test]
+    fn make_empty_workbench() {
+        let wb = Workbench::new("Test Workbench");
+        assert_eq!(wb.history.len(), 4);
+        assert_eq!(wb.get_first_plane_id().unwrap(), "Plane-0".to_owned());
+        assert_eq!(wb.last_plane_id().unwrap(), "Plane-2".to_owned());
+        assert_eq!(wb.plane_name_to_id("Front").unwrap(), "Plane-0".to_owned());
+        assert_eq!(wb.plane_name_to_id("Right").unwrap(), "Plane-1".to_owned());
+        assert_eq!(wb.plane_name_to_id("Top").unwrap(), "Plane-2".to_owned());
+
+        let realization = wb.realize(1000);
+        assert_eq!(realization.points.len(), 1); //origin
+        assert_eq!(realization.planes.len(), 3); // origin, front, right, top
+        assert_eq!(realization.sketches.len(), 0);
+        assert_eq!(realization.solids.len(), 0);
+    }
+
+    #[test]
+    fn make_and_workbench_with_extrusion() {
+        let mut wb = Workbench::new("Test Workbench");
+        wb.add_sketch_to_plane("Sketch 1", "Plane-0");
+        let s = wb.get_sketch_mut("Sketch 1").unwrap();
+        let ll = s.add_point(0.0, 0.0);
+        let lr = s.add_point(40.0, 0.0);
+        let ul = s.add_point(0.0, 40.0);
+        let ur = s.add_point(40.0, 40.0);
+        s.add_segment(ll, lr);
+        s.add_segment(lr, ur);
+        s.add_segment(ur, ul);
+        s.add_segment(ul, ll);
+
+        let extrusion = Extrusion::new(
+            "Sketch-0".to_owned(),
+            vec![0],
+            25.0,
+            0.0,
+            Direction::Normal,
+            ExtrusionMode::New,
+        );
+        wb.add_extrusion("Ext1", extrusion);
+
+        let realization = wb.realize(1000);
+        assert_eq!(realization.planes.len(), 3);
+        assert_eq!(realization.sketches.len(), 1);
+        assert_eq!(realization.solids.len(), 1);
+    }
+}


### PR DESCRIPTION
A few smaller things that i thought would be useful that also is abit of testing the water for what people think are good to try to improve.

A few things added to gitignore to get less junk in the status.

Introduce the concept of rust examples, which i think is very useful to run small commandline applications that can produce simple outputs, perhaps depending on inputs in the future. I think it makes more sense to use examples for such things that unit/integration tests (which i think should be validated in asserts, not by what output they produce if that makes sense)

Added abit of unit test on workbench.rs since it didnt have any. I think unit tests in the project probably could benefit from trying to test what actually that file does, not what is done in other files (make add some integration tests for this?)