### PR TITLE
Fix extrusions

### DIFF
--- a/applications/web/src/components/features/Extrusion.svelte
+++ b/applications/web/src/components/features/Extrusion.svelte
@@ -37,32 +37,31 @@
     workbenchIsStale.set(true)
   }
 
-  function sendUpdate() {
-    const faceIdsFromSelection = $currentlySelected
-      .filter(e => e.type === "face")
-      .map(e => e.id)
-      .sort()
-    updateExtrusion(id, data.sketch_id, length, faceIdsFromSelection)
+  function sendUpdate(specificFaceIds?: string[]) {
+    if (specificFaceIds) {
+      updateExtrusion(id, data.sketch_id, length, specificFaceIds)
+    } else {
+      const faceIdsFromSelection = $currentlySelected
+        .filter(e => e.type === "face")
+        .map(e => e.id)
+        .sort()
+      updateExtrusion(id, data.sketch_id, length, faceIdsFromSelection)
+    }
   }
 
-  currentlySelected.subscribe(e => {
+  currentlySelected.subscribe(store => {
     if ($featureIndex !== index) return
 
-    // log("[$currentlySelected]", $currentlySelected)
-    // log("[$featureIndex]", typeof $featureIndex, $featureIndex)
-
-    const faceIdsFromSelection = $currentlySelected
+    const faceIdsFromSelection = store
       .filter(e => e.type === "face")
       .map(e => e.id)
       .sort()
-
-    // log("[closeAndRefresh] ids from inputs and from selection:", faceIdsFromInputs, faceIdsFromSelection)
 
     if (arraysEqual(faceIdsFromInputs, faceIdsFromSelection)) {
       // log("[closeAndRefresh] face ids are the same, no update")
     } else {
       // log("[closeAndRefresh] triggering update to new face Ids:", faceIdsFromSelection)
-      sendUpdate()
+      sendUpdate(faceIdsFromSelection)
     }
   })
 

--- a/packages/cadmium/src/extrusion.rs
+++ b/packages/cadmium/src/extrusion.rs
@@ -16,7 +16,7 @@ use crate::archetypes::{Point3, Vector3};
 use crate::project::{RealPlane, RealSketch};
 use crate::sketch::{arc_to_points, Face, Sketch};
 
-use truck_modeling::{Point3 as TruckPoint3, Surface, Plane};
+use truck_modeling::{Plane, Point3 as TruckPoint3, Surface};
 
 use truck_topology::Solid as TruckSolid;
 
@@ -384,21 +384,22 @@ fn are_coplanar(p0: Plane, p1: Plane) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::project::Project;
     use crate::project::tests::create_test_project;
+    use crate::project::Project;
 
     #[allow(unused_imports)]
     use super::*;
 
     #[test]
     fn create_project_solid() {
-        let mut p = Project::new("Test Extrusion");
+        // Demonstrate creating a project and then realizing one solid
+        let p = create_test_project();
 
         // now get solids? save as obj or stl or step?
-        let workbench = p.workbenches.get_mut(0).unwrap();
+        let workbench = p.workbenches.get(0).unwrap();
         let realization = workbench.realize(100);
         let solids = realization.solids;
-        println!("solids: {:?}", solids);
+        assert!(solids.len() == 1);
     }
 
     #[test]
@@ -443,5 +444,4 @@ mod tests {
         realization.save_solid_as_step_file(keys[0], "pkg/test.step");
         realization.save_solid_as_obj_file(keys[0], "pkg/test.obj", 0.001);
     }
-
 }


### PR DESCRIPTION
The main issue as far as I can tell is that when you do this:

```
currentlySelected.subscribe(store, {
    console.log($currentlySelected)
})
```
You only have access to the _old_ value of $currentlySelected. To get the latest you have to use:
```
currentlySelected.subscribe(store, {
    console.log(store)
})
```


This fixes https://github.com/CADmium-Co/CADmium/issues/71