### PR TITLE
#73: add discord link, update phosphor-svelte

### DIFF
--- a/applications/web/package.json
+++ b/applications/web/package.json
@@ -23,7 +23,7 @@
     "eslint": "^9.3.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-svelte": "^2.39.0",
-    "phosphor-svelte": "^1.4.2",
+    "phosphor-svelte": "^2.0.1",
     "postcss": "^8.4.38",
     "postcss-load-config": "^5.1.0",
     "prettier": "^3.2.5",

--- a/applications/web/src/components/AppBar.svelte
+++ b/applications/web/src/components/AppBar.svelte
@@ -5,6 +5,8 @@
   import Download from "phosphor-svelte/lib/Download"
   import Upload from "phosphor-svelte/lib/Upload"
   import Bug from "phosphor-svelte/lib/Bug"
+  import DiscordLogo from "phosphor-svelte/lib/DiscordLogo"
+  import GithubLogo from "phosphor-svelte/lib/GithubLogo"
   import type {WithTarget} from "shared/types"
   import {isProject} from "shared/typeGuards"
   import {base} from "../base"
@@ -112,7 +114,10 @@
 
     <div class="flex-grow flex flex-row-reverse gap-4 mr-4">
       <div>
-        <a href="https://github.com/mattferraro/cadmium"><img class="h-6 w-6" src="{base}/github-mark.svg" alt="github logo" /></a>
+        <a href="https://discord.com/invite/qJCsKJeyZv"><DiscordLogo class="h-6 w-6"/></a>
+      </div>
+      <div>
+        <a href="https://github.com/mattferraro/cadmium"><GithubLogo class="h-6 w-6"/></a>
       </div>
     </div>
   </div>

--- a/applications/web/src/components/AppBar.svelte
+++ b/applications/web/src/components/AppBar.svelte
@@ -114,10 +114,10 @@
 
     <div class="flex-grow flex flex-row-reverse gap-4 mr-4">
       <div>
-        <a href="https://discord.com/invite/qJCsKJeyZv"><DiscordLogo class="h-6 w-6"/></a>
+        <a href="https://discord.com/invite/qJCsKJeyZv" target="_blank"><DiscordLogo class="h-6 w-6"/></a>
       </div>
       <div>
-        <a href="https://github.com/mattferraro/cadmium"><GithubLogo class="h-6 w-6"/></a>
+        <a href="https://github.com/mattferraro/cadmium" target="_blank"><GithubLogo class="h-6 w-6"/></a>
       </div>
     </div>
   </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^2.39.0
         version: 2.39.0(eslint@9.4.0)(svelte@5.0.0-next.141)
       phosphor-svelte:
-        specifier: ^1.4.2
-        version: 1.4.2(svelte@5.0.0-next.141)
+        specifier: ^2.0.1
+        version: 2.0.1(svelte@5.0.0-next.141)
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -1513,8 +1513,8 @@ packages:
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
 
-  phosphor-svelte@1.4.2:
-    resolution: {integrity: sha512-wdHKlZbE5D3ad1dd4K9bqWxpOb6gIwe+/ZeXGI9YpdKqECxqd+g3/NsLYE1+/hjlXixTWhQ7VMVIxTtBRXegCg==}
+  phosphor-svelte@2.0.1:
+    resolution: {integrity: sha512-2Ryvaf1sfCNOF0zTQVghtxOs/6JKn9MV+e9uluNAT9wAosgNYnaBD210WcFGRrva1sF8cddv7EWSS//ITNN4mg==}
     peerDependencies:
       svelte: '>=3'
 
@@ -3442,7 +3442,7 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
-  phosphor-svelte@1.4.2(svelte@5.0.0-next.141):
+  phosphor-svelte@2.0.1(svelte@5.0.0-next.141):
     dependencies:
       svelte: 5.0.0-next.141
 


### PR DESCRIPTION
This PR adds a Discord link.

I took the liberty of upgrading Phosphor-svelte and using its built in GitHub and Discord icons. I didn't delete the github icon svg but it should no longer be necessary. If you like this approach let me know and I can remove it.

<img width="313" alt="image" src="https://github.com/CADmium-Co/CADmium/assets/188558/faaca7fc-4aef-41dc-9f30-63eda86d45d4">
