### PR TITLE
fix devcontainer by forcing vite to use IPv4 localhost IP address

### DIFF
--- a/applications/web/vite.config.ts
+++ b/applications/web/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   },
   server: {
     strictPort: true,
+    host: "127.0.0.1",
     port: 5173,
     fs: {
       // Allow serving files from one level up to the project root


### PR DESCRIPTION
I ran into this issue on my Windows 11 + WSL + DevContainer setup: https://github.com/vitejs/vite/issues/16522

This change _should_ be innocuous to across Windows / MacOS and Linux, devcontainer and not.

I was able to test with Windows WSL and Windows WSL + Devcontainer, I could test MacOS and Linux later if that's helpful.