### PR TITLE
removed unused variable userName in AppBar

### DIFF
--- a/applications/web/src/components/AppBar.svelte
+++ b/applications/web/src/components/AppBar.svelte
@@ -12,7 +12,6 @@
 
   const log = (function () { const context = "[AppBar.svelte]"; const color="gray"; return Function.prototype.bind.call(console.log, console, `%c${context}`, `font-weight:bold;color:${color};`)})() // prettier-ignore
 
-  export let userName = "mattferraro.dev"
   export let project: Project
   export let renaming: boolean = false
   export let newProjectName: string = ""


### PR DESCRIPTION
in my other PRs I had noticed this variable was unused but didn't have any context to know what to do with it.

Then I noticed its usage was just removed a few hours ago (https://github.com/CADmium-Co/CADmium/pull/77), so figured this was just missed.

