### PR TITLE
web: reimplement new line tool state with stack instead of nested ifs

### DIFF
--- a/applications/web/src/components/tools/NewLine.svelte
+++ b/applications/web/src/components/tools/NewLine.svelte
@@ -49,10 +49,8 @@
   }
 
   export function click(_event: Event, projected: Point) {
-    if ($snapPoints.length > 0) {
-      log("[click] [snapPoints]", $snapPoints)
-      processPoint($snapPoints[0])
-    } else processPoint({twoD: projected.twoD, threeD: projected.threeD, id: null})
+    if ($snapPoints.length > 0) processPoint($snapPoints[0])
+    else processPoint({twoD: projected.twoD, threeD: projected.threeD, id: null})
   }
 
   export function mouseMove(_event: Event, projected: {x: number; y: number}) {

--- a/applications/web/src/components/tools/NewLine.svelte
+++ b/applications/web/src/components/tools/NewLine.svelte
@@ -27,6 +27,7 @@
 
   function processPoint(point: PointLikeById) {
     pushToStack(point)
+    previousPoint = point
 
     switch (stack.length) {
       case 0: // nothing to do, the stack is empty
@@ -40,9 +41,11 @@
 
         // leave the current point on the stack in case we want to create another line from here
         pushToStack(point)
+        // unless it's an earlier point, which means we're finished making lines, so we clear the stack
+        const isEarlierPoint = !!pointsById[point.id!]
+        if (isEarlierPoint) clearStack()
         break
     }
-    previousPoint = point
   }
 
   export function click(_event: Event, projected: Point) {

--- a/applications/web/src/components/tools/NewLine.svelte
+++ b/applications/web/src/components/tools/NewLine.svelte
@@ -15,8 +15,13 @@
   $: if ($sketchTool !== "line") clearStack()
 
   function pushToStack(point: PointLikeById) {
+    // point should have the following properties:
+    // - twoD: an object with x and y properties representing the point in 2D space
+    // - threeD: an object with x, y, and z properties representing the point in 3D space
+    // - id: a string representing the id of the point in the sketch
+    // If the id is nullish we call addPointToSketch to create a new point in the sketch.
     if (!point) return
-    if (!point.id) point.id = addPointToSketch(sketchIndex, point.twoD, false)
+    point.id = point.id ?? addPointToSketch(sketchIndex, point.twoD, false)
     stack.push(point)
   }
 
@@ -29,11 +34,11 @@
       case 1: // can't create a line with only one point!
         break
       default:
-        const previousPoint = stack[stack.length - 2]
-        addLineToSketch(sketchIndex, +previousPoint.id!, +point!.id!)
-        popFromStack()
-        popFromStack()
-        // leave the last point on the stack in case we want to create another line from that point
+        const endPoint = popFromStack()
+        const startPoint = popFromStack()
+        addLineToSketch(sketchIndex, +startPoint.id, +endPoint.id)
+
+        // leave the current point on the stack in case we want to create another line from here
         pushToStack(point)
         break
     }


### PR DESCRIPTION
I find the ui state code when using the modeling tools confusing. Rather than a bunch of nested ifs and else ifs it's simpler implemented as a stack.