### PR TITLE
Generate higher quality meshes

### DIFF
--- a/packages/cadmium/src/solid.rs
+++ b/packages/cadmium/src/solid.rs
@@ -26,8 +26,6 @@ use truck_polymesh::Point3 as TruckPoint3;
 use truck_polymesh::Vector3 as TruckVector3;
 use truck_topology::Solid as TruckSolid;
 
-const MESH_TOLERANCE: f64 = 0.1;
-
 #[derive(Tsify, Debug, Serialize, Deserialize, Clone)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct Solid {
@@ -64,8 +62,7 @@ impl Solid {
             indices: vec![],
             truck_solid,
         };
-        let mut mesh = solid.truck_solid.triangulation(MESH_TOLERANCE).to_polygon();
-        mesh.put_together_same_attrs(0.1);
+        let mesh = solid.truck_solid.triangulation(0.01).to_polygon();
 
         // the mesh is prepared for obj export, but we need to convert it
         // to a format compatible for rendering
@@ -295,8 +292,7 @@ impl Solid {
     }
 
     pub fn to_obj_string(&self, tolerance: f64) -> String {
-        let mut mesh = self.truck_solid.triangulation(tolerance).to_polygon();
-        mesh.put_together_same_attrs(0.1);
+        let mesh = self.truck_solid.triangulation(tolerance).to_polygon();
         let mut buf = Vec::new();
         obj::write(&mesh, &mut buf).unwrap();
         let string = String::from_utf8(buf).unwrap();
@@ -304,8 +300,7 @@ impl Solid {
     }
 
     pub fn save_as_obj(&self, filename: &str, tolerance: f64) {
-        let mut mesh = self.truck_solid.triangulation(tolerance).to_polygon();
-        mesh.put_together_same_attrs(0.1);
+        let mesh = self.truck_solid.triangulation(tolerance).to_polygon();
         let file = std::fs::File::create(filename).unwrap();
         obj::write(&mesh, file).unwrap();
     }


### PR DESCRIPTION
This PR removes the deprecated calls to `put_together_some_attrs` and also correctly threads through the `tolerance` parameter when directly generating obj files.

Addresses https://github.com/CADmium-Co/CADmium/issues/85

Before:

<img width="600" alt="Screenshot 2024-06-02 at 9 58 02 PM" src="https://github.com/CADmium-Co/CADmium/assets/1302431/c2b9dfde-160d-481b-b798-8e92396acd34">

After:

<img width="600" alt="Screenshot 2024-06-02 at 9 56 56 PM" src="https://github.com/CADmium-Co/CADmium/assets/1302431/dd81cdd9-ade7-45a0-9594-4ca3353d98cb">

Note that this makes the meshes much heavier--about 10x as many triangles in general. This will eventually create a problem for us! See also https://github.com/ricosjp/truck/issues/70 which, among other things, requests lower triangle counts.