### PR TITLE
fix threejs version

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "cadmium": "workspace:*",
     "svelte": "^4.2.12",
-    "three": "^0.162.0"
+    "three": "^0.164.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
         specifier: ^4.2.12
         version: 4.2.17
       three:
-        specifier: ^0.162.0
-        version: 0.162.0
+        specifier: ^0.164.1
+        version: 0.164.1
 
 packages:
 
@@ -1906,9 +1906,6 @@ packages:
     resolution: {integrity: sha512-lCur/i8U6m0ysWYhQ1yFGWOZB0QA2oVsDsfynYd65HhXxLxJfiAt8OsXmpv9PnTLacfaZclBcZHUOB9QKk3eaw==}
     peerDependencies:
       three: '>=0.151'
-
-  three@0.162.0:
-    resolution: {integrity: sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==}
 
   three@0.164.1:
     resolution: {integrity: sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==}
@@ -3847,8 +3844,6 @@ snapshots:
       three: 0.164.1
       troika-three-text: 0.47.2(three@0.164.1)
       tweakpane: 3.1.10
-
-  three@0.162.0: {}
 
   three@0.164.1: {}
 


### PR DESCRIPTION
I noticed two copies of threejs were being installed, the wrong version coming from `packages/shared`. I tried moving all the shared dependencies to this file so they wouldn't be declared twice, but [that seems to be a bug](https://stackoverflow.com/questions/77942163/pnpm-not-installing-transitive-workspace-dependency-in-nx-monorepo).