### PR TITLE
Fix #90 by clearing depth buffer

### DIFF
--- a/applications/web/src/components/controls/CubeGizmo/CubeGizmo.svelte
+++ b/applications/web/src/components/controls/CubeGizmo/CubeGizmo.svelte
@@ -75,6 +75,7 @@
       const y = verticalPlacement === "bottom" ? paddingY : renderer.domElement.offsetHeight - size - paddingY
 
       renderer.setViewport(x, y, size, size)
+      renderer.clearDepth()
       renderer.render(rotationRoot, orthoCam)
       renderer.render(triangleControls, orthoCam)
       renderer.setViewport(viewport.x, viewport.y, viewport.z, viewport.w)


### PR DESCRIPTION
This prevents the solids in the viewport from being able to hide the Gizmo. Fixes #90 